### PR TITLE
Not everyone has a cat; polyfill it

### DIFF
--- a/shab
+++ b/shab
@@ -5,21 +5,15 @@
 # Usage: shab [template-file|-]
 set -euo pipefail
 
-if type cat &>/dev/null; then
-    dog() { cat "$@"; }
-else
-    dog() { # eponymously slow cat-polyfill hostile to nulls
-        [ ${#@} -ne 0 ] || set -- -
-        for fn; do
-            [ "$fn" != - ] || fn=/dev/stdin
-            while IFS= read -r line; do
-                printf "%s\n" "$line"
-            done <"$fn"
-            printf "%s" "$line"
-        done
-    }
-fi
-export -f dog
+dog() { # eponymously slow cat ersatz hostile to nulls
+    [[ "${1-}" != - ]] || set --
+    eval '
+    while IFS= read -r line; do
+        printf "%s\n" "$line"
+    done '${1+<"$1"}'
+    printf "%s" "$line"
+    '
+}
 shab() {(
   local id=${RANDOM}_${RANDOM}
   eval "$(echo "set -eu; dog <<SHAB_$id"; dog "${1:--}"; echo; echo "SHAB_$id")"

--- a/shab
+++ b/shab
@@ -5,9 +5,24 @@
 # Usage: shab [template-file|-]
 set -euo pipefail
 
+if type cat &>/dev/null; then
+    dog() { cat "$@"; }
+else
+    dog() { # eponymously slow cat-polyfill hostile to nulls
+        [ ${#@} -ne 0 ] || set -- -
+        for fn; do
+            [ "$fn" != - ] || fn=/dev/stdin
+            while IFS= read -r line; do
+                printf "%s\n" "$line"
+            done <"$fn"
+            printf "%s" "$line"
+        done
+    }
+fi
+export -f dog
 shab() {(
   local id=${RANDOM}_${RANDOM}
-  eval "$(echo "set -eu; cat <<SHAB_$id"; cat "${1:--}"; echo; echo "SHAB_$id")"
+  eval "$(echo "set -eu; dog <<SHAB_$id"; dog "${1:--}"; echo; echo "SHAB_$id")"
 )}
 
 # Works both as a sourced file or executable


### PR DESCRIPTION
A hard external dependency gone where bash gets the job done. It might often be
a few orders of magnitude slower for larger files, but computers are plenty fast
these days and users plenty patient. In fact for the intended use case dog may
be faster than cat:

```
~/repo/shab$ time dog example.shab >/dev/null
real	0m0.002s
user	0m0.001s
sys	0m0.000s

~/repo/shab$ time cat example.shab >/dev/null
real	0m0.004s
user	0m0.002s
sys	0m0.002s
```