### PR TITLE
shab: clarify "nulls" in inline doc

### DIFF
--- a/shab
+++ b/shab
@@ -7,7 +7,7 @@
 # Usage: shab [template-file|-]
 set -euo pipefail
 
-# eponymously slow cat ersatz hostile to nulls
+# eponymously slow cat ersatz hostile to NUL bytes
 dog() (
   if [[ $1 = - ]]; then
     exec 3<&0


### PR DESCRIPTION
Found this doc improvement while evaluating shab for a real world use case.

Didn't do it because generating bash with shab is confusing.
